### PR TITLE
change rubyio.h header to ruby/io.h

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'http://rubygems.org'
+
+gemspec

--- a/extconf.rb
+++ b/extconf.rb
@@ -37,9 +37,9 @@ require 'mkmf'
 have_library("ncurses", "setupterm") or
 have_library("curses", "setupterm") 
 
-have_type("rb_io_t", ["ruby.h", "rubyio.h"])
-have_struct_member("rb_io_t", "fd", ["ruby.h", "rubyio.h"])
-have_struct_member("OpenFile", "fd", ["ruby.h", "rubyio.h"])
+have_type("rb_io_t", ["ruby.h", "ruby/io.h"])
+have_struct_member("rb_io_t", "fd", ["ruby.h", "ruby/io.h"])
+have_struct_member("OpenFile", "fd", ["ruby.h", "ruby/io.h"])
 
 create_header
 create_makefile('terminfo')
@@ -50,4 +50,3 @@ rdoc:
 	rdoc --op rdoc terminfo.c lib/terminfo.rb
 End
 }
-

--- a/terminfo.c
+++ b/terminfo.c
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "ruby.h"
-#include "rubyio.h"
+#include "ruby/io.h"
 #include "extconf.h"
 
 #include <curses.h>


### PR DESCRIPTION
The header file has moved from rubyio.h to ruby/io.h.  Without this change, compilation would fail.  If you don't want the default Gemfile added, I'm fine with dropping that commit and submitting another pull request.

fixes #2 